### PR TITLE
Disable carburetor and choke module imports

### DIFF
--- a/combustionEngine.lua
+++ b/combustionEngine.lua
@@ -20,8 +20,8 @@ M.outputPorts = { [1] = true } -- set dynamically
 M.deviceCategories = { engine = true }
 
 local delayLine = rerequire("delayLine")
-local carburetorModule = rerequire("lua/vehicle/powertrain/carburetor")
-local chokeModule = rerequire("lua/vehicle/powertrain/choking")
+--[[local carburetorModule = rerequire("lua/vehicle/powertrain/carburetor")
+local chokeModule = rerequire("lua/vehicle/powertrain/choking")]]
 
 local max = math.max
 local min = math.min


### PR DESCRIPTION
Comment out the carburetor and choke module requires as those scripts are still being debugged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lonewolf0708/betterbeamengine/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
