### PR TITLE
Remove duplicate debugFuel variable

### DIFF
--- a/combustionEngine.lua
+++ b/combustionEngine.lua
@@ -2522,7 +2522,6 @@ end
 
 				-- Add fuel to cylinder with a minimum amount
 				local newFuel = math.min(maxFuelPerCylinder, cylinder.fuelAmount + fuelAmount * dt * 0.8)
-				local debugFuel = false
 
 				-- Debug output for fuel addition with rate limiting
 				if debugFuel and fuelAmount > 0 then


### PR DESCRIPTION
Removed debugFuel variable to clean up code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lonewolf0708/betterbeamengine/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
